### PR TITLE
Update pin-code.js

### DIFF
--- a/Pin Code Lock/pin-code.js
+++ b/Pin Code Lock/pin-code.js
@@ -17,6 +17,7 @@ function onResponse(code) {
   if (code === PIN_CODE)
   {
     console.log('pin correct');
+    xapi.config.set('UserInterface Features HideAll', 'False');
   }
   else {
     console.log('pin failed');
@@ -35,7 +36,10 @@ function listenToEvents() {
     }
   });
   xapi.status.on('Standby State', (state) => {
-    if (state === 'Off') askForPin();
+    if (state === 'Off') {
+      xapi.config.set('UserInterface Features HideAll', 'True');
+      askForPin();
+    }
   });
 }
 


### PR DESCRIPTION
The added 2 lines remove the call button should the user select cancel at the message prompt for the pin code.  This allows the user to cancel the PIN request and use the room for local presentation - the text for the request could also be updated to 'Enter PIN code for video conferencing or select cancel for local presentation'