### PR TITLE
fix (philips-hue): use convert to string

### DIFF
--- a/Philips Hue/hue-lib.js
+++ b/Philips Hue/hue-lib.js
@@ -92,8 +92,8 @@ class Hue {
   //  sat [0-255] // saturation
   // }
   setLightState(id, state) {
-    const isGroup = id.startsWith('g');
-    id = id.replace('g', '');
+    const isGroup = id.toString().startsWith('g');
+    id = id.toString().replace('g', '');
 
     const path = isGroup ? `groups/${id}/action` : `lights/${id}/state`;
     const url = `https://${this.ip}/api/${this.token}/${path}`;


### PR DESCRIPTION
Example macros within the [Philips Hue/examples](https://github.com/CiscoDevNet/roomdevices-macros-samples/tree/3df1f4daea6ee3a496bca27dbd6a5b86ddd7cbd3/Philips%20Hue/examples) folder suggest using integer values for hue id.

Examples:
- https://github.com/CiscoDevNet/roomdevices-macros-samples/blob/3df1f4daea6ee3a496bca27dbd6a5b86ddd7cbd3/Philips%20Hue/examples/incall-indicator.js#L6
- https://github.com/CiscoDevNet/roomdevices-macros-samples/blob/3df1f4daea6ee3a496bca27dbd6a5b86ddd7cbd3/Philips%20Hue/examples/incoming-call-blink.js#L6
- https://github.com/CiscoDevNet/roomdevices-macros-samples/blob/3df1f4daea6ee3a496bca27dbd6a5b86ddd7cbd3/Philips%20Hue/examples/presence-indicator.js#L6
- https://github.com/CiscoDevNet/roomdevices-macros-samples/blob/3df1f4daea6ee3a496bca27dbd6a5b86ddd7cbd3/Philips%20Hue/examples/temperature.js#L6
- https://github.com/CiscoDevNet/roomdevices-macros-samples/blob/3df1f4daea6ee3a496bca27dbd6a5b86ddd7cbd3/Philips%20Hue/examples/virtual-background.js#L6

However these give an error when setting light state since `.startsWith()` applies only to string types.
https://github.com/CiscoDevNet/roomdevices-macros-samples/blob/3df1f4daea6ee3a496bca27dbd6a5b86ddd7cbd3/Philips%20Hue/hue-lib.js#L94-L101